### PR TITLE
Support added for avaspark-rgb board target. Fixed being able to d…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,7 @@
 [platformio]
 default_envs = wemos_d1_mini32
 ;default_envs = nodemcu-32s
+;default_envs = avaspark-andonn
 
 [common_env_data]
 lib_deps_external =
@@ -38,6 +39,24 @@ build_flags=
   -D CAN_TX_PIN=_26
   -D CAN_RX_PIN=_27
 
+[AVASPARK-ANDONN]
+build_flags=
+  -D PIN_NEOPIXEL_FRONT=18    ; DIN of WS28xx stripe for front light, only needed if WS28xx is used
+  -D PIN_NEOPIXEL_BACK=17     ; DIN of WS28xx stripe for back light, only needed if WS28xx is used
+  ;-D MOSFET_PIN_1=22   ; PWM signal for MOSFET 1 (front white, back red), only needed if COB is used
+  ;-D MOSFET_PIN_2=23   ; PWM signal for MOSFET 2 (front red, back white), only needed if COB is used
+  ;-D PIN_FORWARD=18    ; digital signal from Cheap Focer 2 if direction is forward
+  ;-D PIN_BACKWARD=19   ; digital signal from Cheap Focer 2 if direction is backward
+  ;-D PIN_BRAKE=21      ; digital signal from Cheap Focer 2 if electric motor brakes is on
+  -D BUZPIN=19         ; PIN for Piezo buzzer for acoustic signals (e.g. battery warning)
+  -D BATTERY_PIN=34    ; analog input for battery monitor, connected to voltage divider
+  -D LIGHT_BAR_PIN=4   ; DIN of WS28xx for battery indicator
+  -D VESC_RX_PIN=27    ; UART RX to Cheap Focer 2, connent to TX on CF2
+  -D VESC_TX_PIN=25    ; UART TX to Cheap Focer 2, connent to RX on CF2
+  -D CAN_TX_PIN=_33
+  -D CAN_RX_PIN=_32
+  -D PIN_BOARD_LED=16 ; Onboard LED for avaspark-andonn
+
 [env:native]
 platform = native
 
@@ -64,3 +83,14 @@ lib_deps =
     ${common_env_data.lib_deps_external}
 build_flags =
      ${ESP32.build_flags}
+
+[env:avaspark-andonn]
+platform = espressif32
+board = nodemcu-32s
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = default.csv
+lib_deps =
+    ${common_env_data.lib_deps_external}
+build_flags =
+     ${AVASPARK-ANDONN.build_flags}

--- a/src/CanDevice.cpp
+++ b/src/CanDevice.cpp
@@ -1,7 +1,7 @@
 #include "CanDevice.h"
 
 void CanDevice::init() {
-    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(GPIO_NUM_26, GPIO_NUM_27, TWAI_MODE_NORMAL);
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(GPIO_CAN_TX_PIN, GPIO_CAN_RX_PIN, TWAI_MODE_NORMAL);
     g_config.rx_queue_len=1000;
     g_config.tx_queue_len=10;
     twai_timing_config_t t_config = TWAI_TIMING_CONFIG_500KBITS();

--- a/src/CanDevice.h
+++ b/src/CanDevice.h
@@ -16,6 +16,12 @@
 #define CAN_RX_PIN 27
 #endif //CAN_RX_PIN
 
+//Macros to fix actually being able to map the CAN GPIO pins in platformio.ini instead of them being hard coded in init() for TWAI_GENERAL_CONFIG_DEFAULT();
+#define GPIO_NUM_HELPER(x) GPIO_NUM##x
+#define GPIO_NUM(x) GPIO_NUM_HELPER(x)
+#define GPIO_CAN_TX_PIN GPIO_NUM(CAN_TX_PIN)
+#define GPIO_CAN_RX_PIN GPIO_NUM(CAN_RX_PIN)
+
 class CanDevice {
   private:
     SemaphoreHandle_t mutex_v = xSemaphoreCreateMutex();

--- a/src/LedControllerFactory.cpp
+++ b/src/LedControllerFactory.cpp
@@ -17,8 +17,13 @@ LedControllerFactory *LedControllerFactory::getInstance() {
 ILedController *LedControllerFactory::createLedController(VescData *vescData) {
 #ifdef LED_WS28xx
     uint8_t ledType = LedControllerFactory::determineLedType();
-    return new Ws28xxController(AppConfiguration::getInstance()->config.numberPixelLight, PIN_NEOPIXEL, ledType, vescData);
-#endif //LED_WS28xx
+    //stuff for using seperate front and back pins. 
+    #if defined(PIN_NEOPIXEL_FRONT) && defined(PIN_NEOPIXEL_BACK)
+        return new Ws28xxController(AppConfiguration::getInstance()->config.numberPixelLight, PIN_NEOPIXEL_FRONT, PIN_NEOPIXEL_BACK, ledType, vescData);
+    #else
+        return new Ws28xxController(AppConfiguration::getInstance()->config.numberPixelLight, PIN_NEOPIXEL, ledType, vescData);
+    #endif //LED_WS28xx
+#endif
 #ifdef LED_COB
     return new CobController();
 #endif //LED_COB

--- a/src/Ws28xxController.h
+++ b/src/Ws28xxController.h
@@ -16,6 +16,7 @@
 class Ws28xxController : public ILedController, Adafruit_NeoPixel {
     public:
         Ws28xxController(uint16_t pixels, uint8_t pin, uint8_t type, VescData *vescData);
+        Ws28xxController(uint16_t pixels, uint8_t frontPin, uint8_t backPin, uint8_t type, VescData *vescData);
         void init() override;
         void stop() override;
         void startSequence() override;
@@ -59,6 +60,15 @@ class Ws28xxController : public ILedController, Adafruit_NeoPixel {
         void onComplete();
 
     private:
+        //stuff for using seperate front and back pins. 
+        Adafruit_NeoPixel frontStrip;
+        Adafruit_NeoPixel backStrip;
+        bool useTwoPins;
+        // Private methods that replace calls to inherited Adafruit_NeoPixel methods
+        void setPixelColor(uint16_t n, uint32_t c);
+        void setPixelColor(uint16_t n, uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
+        void show();
+        uint16_t numPixels() const;
         uint32_t wheel(byte wheelPos);
         void setLight(boolean forward, int brightness);
         uint32_t dimColor(uint32_t color, uint8_t width);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,13 @@ void fakeCanbusValues() {
 #endif
 
 void setup() {
+
+//Debug LED on board
+#ifdef PIN_BOARD_LED
+    pinMode(PIN_BOARD_LED,OUTPUT);
+    digitalWrite(PIN_BOARD_LED,LOW);
+#endif
+
     Logger::setOutputFunction(localLogger);
 
     AppConfiguration::getInstance()->readPreferences();
@@ -78,12 +85,16 @@ void setup() {
         return;
     }
 
+
+
     ledController = LedControllerFactory::getInstance()->createLedController(&vescData);
 
+    #if defined(PIN_FORWARD) && defined(PIN_BACKWARD) && defined(PIN_BRAKE)
     pinMode(PIN_FORWARD, INPUT);
     pinMode(PIN_BACKWARD, INPUT);
     pinMode(PIN_BRAKE, INPUT);
-
+    #endif
+    
     vesc.begin(VESC_BAUD_RATE, SERIAL_8N1, VESC_RX_PIN, VESC_TX_PIN, false);
     delay(50);
 #ifdef CANBUS_ENABLED
@@ -110,6 +121,10 @@ void setup() {
              SOFTWARE_VERSION_MAJOR, SOFTWARE_VERSION_MINOR, SOFTWARE_VERSION_PATCH,
              HARDWARE_VERSION_MAJOR, HARDWARE_VERSION_MINOR);
     Logger::notice("rESCue", buf);
+
+#ifdef PIN_BOARD_LED
+    digitalWrite(PIN_BOARD_LED,HIGH);
+#endif
 }
 
 void loop() {


### PR DESCRIPTION
…efine CAN bus pins as opposed to hardcoded. Overloaded Ws28xxController setPixelColor functions to support seperate front/back GPIO pins for LEDs.