### PR TITLE
Fix save config crash.

### DIFF
--- a/src/AppConfiguration.cpp
+++ b/src/AppConfiguration.cpp
@@ -59,8 +59,8 @@ boolean AppConfiguration::readPreferences() {
     config.lightbarTurnOffErpm =  doc["lightbarTurnOffErpm"] | 1000;
     config.ledType = doc["ledType"] | "RGB";
     config.lightBarLedType = doc["lightBarLedType"] | "GRB";
-    config.ledFrequency = doc["ledFrequency"] | "KHZ800";
-    config.lightBarLedFrequency = doc["lightBarLedFrequency"] | "KHZ800";
+    config.ledFrequency = doc["ledFrequency"] | "800kHz";
+    config.lightBarLedFrequency = doc["lightBarLedFrequency"] | "800kHz";
     config.isLightBarReversed = doc["isLightBarReversed"] | false;
     config.isLightBarLedTypeDifferent = doc["isLightBarLedTypeDifferent"] | false;
     config.idleLightTimeout = doc["idleLightTimeout"] | 60000;
@@ -127,7 +127,9 @@ boolean AppConfiguration::savePreferences() {
 }
 
 boolean AppConfiguration::readMelodies() {
+    return true;
 }
 
 boolean AppConfiguration::saveMelodies() {
+    return true;
 }

--- a/src/BleServer.cpp
+++ b/src/BleServer.cpp
@@ -253,7 +253,7 @@ void BleServer::onWrite(BLECharacteristic *pCharacteristic) {
                 key = str.substr(0, middle);
                 value = str.substr(middle + 1, str.size() - (middle + 1));
             }
-
+            
             //Serial.println(String(key.c_str()) + String("=") + String(value.c_str()));
 
             if (key == "config") {
@@ -327,6 +327,16 @@ void BleServer::onWrite(BLECharacteristic *pCharacteristic) {
                 AppConfiguration::getInstance()->config.ledType = value.c_str();
             } else if (key == "ledFrequency") {
                 AppConfiguration::getInstance()->config.ledFrequency = value.c_str();
+            } else if (key == "lightBarLedType") {
+                AppConfiguration::getInstance()->config.lightBarLedType = value.c_str();
+            } else if (key == "lightBarLedFrequency") {
+                AppConfiguration::getInstance()->config.lightBarLedFrequency = value.c_str();
+            } else if (key == "isLightBarReversed") {
+                AppConfiguration::getInstance()->config.isLightBarReversed = value.c_str();
+            } else if (key == "isLightBarLedTypeDifferent") {
+                AppConfiguration::getInstance()->config.isLightBarLedTypeDifferent = value.c_str();
+            } else if (key == "mallGrab") {
+                AppConfiguration::getInstance()->config.mallGrab = value.c_str();
             } else if (key == "logLevel") {
                 AppConfiguration::getInstance()->config.logLevel = static_cast<Logger::Level>(strtol(value.c_str(), nullptr, 10));
             } else if (key == "mtuSize") {
@@ -420,7 +430,7 @@ struct BleServer::sendConfigValue {
         pCharacteristic->setValue(ss.str());
         pCharacteristic->notify();
         ss.str("");
-        delay(1);
+        delay(bleWait);
     }
 };
 

--- a/src/LedControllerFactory.cpp
+++ b/src/LedControllerFactory.cpp
@@ -64,7 +64,7 @@ uint8_t LedControllerFactory::determineLedType(bool lightBar) {
     } else {
         ledFreqStr = std::string(AppConfiguration::getInstance()->config.ledFrequency.c_str());
     }
-    if (ledFreqStr == "KHZ800") {
+    if (ledFreqStr == "800kHz") {
         ledType = ledType + 0x0000;
     } else {
         ledType = ledType + 0x0100;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,7 @@ void loop() {
     }
     if (AppConfiguration::getInstance()->config.saveConfig) {
         AppConfiguration::getInstance()->savePreferences();
-        AppConfiguration::getInstance()->saveMelodies();
+        //AppConfiguration::getInstance()->saveMelodies();
         AppConfiguration::getInstance()->config.saveConfig = false;
     }
 


### PR DESCRIPTION
Fix null pointer dereference when loading config from saveMelodies.
Fix actually loading new vars from rESCue Tool
change LedFreqStr name (also changed in rESCue Tool PR)