### PR TITLE
reboot now after applying new config to apply new vesc id immediate

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,10 @@ void loop() {
         AppConfiguration::getInstance()->savePreferences();
         //AppConfiguration::getInstance()->saveMelodies();
         AppConfiguration::getInstance()->config.saveConfig = false;
+
+        // reboot to take over config, specially for the vesc can id
+        ESP_LOGI("rESCue", "Rebooting to take over new saved config...");
+        ESP.restart();
     }
 
 #ifdef CANBUS_ENABLED


### PR DESCRIPTION
When you click in settings on the rescue app on "save and reboot" the config gets written to rescue

however rescue itself does not reboot, this causes that a new can vesc id gets not applied
so you have to reboot your rescue yourself, to avoid this i added a reboot after writing the config so everything gets now applied immediate