### PR TITLE
Fix footpad unknown switch state

### DIFF
--- a/src/LightBarController.cpp
+++ b/src/LightBarController.cpp
@@ -137,6 +137,8 @@ AdcState LightBarController::mapSwitchState(uint16_t intState, boolean isAdc1Ena
         case 1:
             return isAdc1Enabled ? AdcState::ADC_HALF_ADC1 : AdcState::ADC_HALF_ADC2;
         case 2:
+            return AdcState::ADC_HALF_ADC2;
+        case 3:
             return AdcState::ADC_FULL;
         default:
             ESP_LOGE(LOG_TAG_LIGHTBAR, "Unknown switch state");


### PR DESCRIPTION
This PR should fix unknown switch state error that causes status bar behaviour described in this issue: https://github.com/thankthemaker/rESCue/issues/88

switchState set in Canbus.cpp was not corresponding to switchState mapper in LightBarController.cpp

https://github.com/thankthemaker/rESCue/blob/ccd3f1fbd6c5233aa7bd50aa8649efeadf8381ec/src/CanBus.cpp#L632-L643

https://github.com/thankthemaker/rESCue/blob/ccd3f1fbd6c5233aa7bd50aa8649efeadf8381ec/src/LightBarController.cpp#L134-L143